### PR TITLE
add one paper on GR at SIGIR'24

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,10 @@ Arxiv 2022 [[paper](https://arxiv.org/pdf/2208.09257.pdf)]
 
 ### Generate a string as an identifier
 
+**Generative Retrieval as Multi-Vector Dense Retrieval**  
+*Shiguang Wu, Wenda Wei, Mengqi Zhang, Zhumin Chen, Jun Ma, Zhaochun Ren, Maarten de Rijke, Pengjie Ren*  
+SIGIR 2024 - March 24 [[paper](https://arxiv.org/abs/2404.00684)] [[Code](https://github.com/Furyton/GR-as-MVDR)]
+
 **Re3val: Reinforced and Reranked Generative Retrieval**  
 *EuiYul Song, Sangryul Kim, Haeju Lee, Joonkee Kim, James Thorne*  
 EACL Findings 2023 – Jan 24 [[paper](https://arxiv.org/pdf/2401.16979.pdf)]


### PR DESCRIPTION
Hi, thanks for maintaining this awesome repo.
Here is our recent work on the theoretical analysis of generative document retrieval accepted at SIGIR'24 "Generative Retrieval as Multi-Vector Dense Retrieval".
Could you please consider adding this article to your repo?